### PR TITLE
Use `DOCKER` variable everywhere, to call `docker`

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -111,7 +111,7 @@ comm -23 containers.all containers.running > containers.exited
 echo -n "" > containers.reap.tmp
 cat containers.exited | while read line
 do
-    EXITED=$(docker inspect -f '{{.State.FinishedAt}}' ${line})
+    EXITED=$(${DOCKER} inspect -f '{{.State.FinishedAt}}' ${line})
     ELAPSED=$(ElapsedTime $EXITED)
     if [[ $ELAPSED -gt $GRACE_PERIOD_SECONDS ]]; then
         echo $line >> containers.reap.tmp
@@ -125,9 +125,9 @@ comm -23 containers.all containers.reap > containers.keep
 # List images used by containers that we keep.
 # This may be both image id's and repo/name:tag, so normalize to image id's only
 cat containers.keep |
-xargs -n 1 docker inspect -f '{{.Config.Image}}' 2>/dev/null |
+xargs -n 1 $DOCKER inspect -f '{{.Config.Image}}' 2>/dev/null |
 sort | uniq |
-xargs -n 1 docker inspect -f '{{.Id}}' 2>/dev/null |
+xargs -n 1 $DOCKER inspect -f '{{.Id}}' 2>/dev/null |
 sort | uniq > images.used
 
 # List images to reap; images that existed last run and are not in use.


### PR DESCRIPTION
Tested in an environment which plain `docker` couldn't work: 

```
DOCKER="docker -H unix:///docker.sock" docker-gc
```

Fixes #7
