### PR TITLE
Update docker-gc to use python 2 explicitly

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -49,7 +49,7 @@ EXCLUDE_IDS_FILE="$STATE_DIR/exclude_ids"
 
 # Elapsed time since a docker timestamp, in seconds
 function ElapsedTime() {
-    python <<END
+    env python2 <<END
 from datetime import datetime,timedelta
 now = datetime.utcnow()
 exited =  datetime.strptime("${1}".replace("Z","").split('.')[0], "%Y-%m-%dT%H:%M:%S")


### PR DESCRIPTION
Some distros (Arch specifically) use python 3 by default.  This updates docker-gc to work on those systems.