### PR TITLE
Avoid image / container name clash and implement "images that existed last run" logic

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -125,16 +125,15 @@ cat containers.reap.tmp | sort | uniq > containers.reap
 comm -23 containers.all containers.reap > containers.keep
 
 # List images used by containers that we keep.
-# This may be both image id's and repo/name:tag, so normalize to image id's only
 cat containers.keep |
-xargs -n 1 $DOCKER inspect -f '{{.Config.Image}}' 2>/dev/null |
-sort | uniq |
-xargs -n 1 $DOCKER inspect -f '{{.Id}}' 2>/dev/null |
+xargs -n 1 $DOCKER inspect -f '{{.Image}}' 2>/dev/null |
 sort | uniq > images.used
 
 # List images to reap; images that existed last run and are not in use.
 $DOCKER images -q --no-trunc | sort | uniq > images.all
-comm -23 images.all images.used | grep -v -f $EXCLUDE_IDS_FILE > images.reap || true
+comm -23 images.all images.used | grep -v -f $EXCLUDE_IDS_FILE > images.not-in-use || true
+touch images.last-run
+comm -12 images.not-in-use images.last-run > images.reap || true
 
 # Reap containers.
 xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
@@ -142,3 +141,5 @@ xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
 # Reap images.
 xargs -n 1 $DOCKER rmi < images.reap &>/dev/null || true
 
+# Save list of images for next run.
+$DOCKER images -q --no-trunc | sort | uniq > images.last-run


### PR DESCRIPTION
docker-gc: use {{.Image}} instead of {{.Config.Image}} to avoid image name / container name clash, also {{.Image}} is always an id so we can simplify the logic here.  Bring functionality into line with the comment "List images to reap; images that existed last run and are not in use." by saving out a list of images to images.last-run and doing a comm -12 next time we can avoid images being removed that a new (in my case freshly built and in the process of being pushed).