### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:jessie
+
+ENV DOCKER_VERSION 1.6.2
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal \
+  && apt-get clean \
+  && rm -rf /var/apt/lists/*
+
+ADD https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} /usr/local/bin/docker
+RUN chmod +x /usr/local/bin/docker
+
+ADD docker-gc /docker-gc
+
+VOLUME /var/lib/docker-gc
+
+CMD ["/docker-gc"]

--- a/README.md
+++ b/README.md
@@ -66,3 +66,17 @@ spotify/cassandra:latest
 9681260c3ad5
 ```
 
+Running as a Docker Image
+-------------------------
+
+A Dockerfile is provided as an alternative to a local installation. By default the container will start up, run a single garbage collection, and shut down.
+
+```sh
+docker build -t spotify/docker-gc .
+```
+
+The docker-gc container requires access to the docker socket in order to function.
+
+```sh
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock spotify/docker-gc
+```


### PR DESCRIPTION
Specifically to allow use on CoreOS and similar setups. Base image is debian:jessie and it expects the docker socket to be mounted in.