### PR TITLE
Change URL for docker binary download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DOCKER_VERSION 1.6.2
 
 # We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it
 RUN apk --update add bash curl python \
-  && curl -s https://get.docker.io/builds/Linux/x86_64/docker-${DOCKER_VERSION} > /bin/docker \
+  && curl -s https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} > /bin/docker \
   && chmod +x /bin/docker \
   && apk del curl \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
I was getting an empty response from the `io` URL, leading to a confusing situation where `docker` was an empty script that silently did nothing with any arguments. `get.docker.io` now redirects to `get.docker.com`, so I'm updating that here.