### PR TITLE
Fix grep difference bug in excluding containers

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -110,12 +110,12 @@ function compute_exclude_container_ids() {
     # Implode their values with a \| separator on a single line
     PROCESSED_EXCLUDES=`cat $EXCLUDE_CONTAINERS_FROM_GC \
         | xargs \
-        | sed -e 's/ /\\\|/g'`
+        | sed -e 's/ /\|/g'`
     # Find all docker images
     # Filter out with matching names 
     # and put them to $EXCLUDE_CONTAINER_IDS_FILE
     $DOCKER ps -a \
-        | grep "$PROCESSED_EXCLUDES" \
+        | grep -E "$PROCESSED_EXCLUDES" \
         | awk '{ print $1 }' \
         | tr -s " " "\012" \
         | sort -u > $EXCLUDE_CONTAINER_IDS_FILE


### PR DESCRIPTION
Function compute_exclude_container_ids introduced with
pull request #38 did not take into account that the
docker-gc container built from the Dockerfile included
a lightweight Linux distribution with a lighter version
of grep which failed if multiple docker container names
were specified.

Modified the function to make use of the extended regex flag.