### PR TITLE
Should mount /etc as volumes when running as a docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,5 +107,5 @@ The docker-gc container requires access to the docker socket in order to
 function, so you need to map it when running, e.g.:
 
 ```sh
-docker run --rm -v /var/run/docker.sock:/var/run/docker.sock spotify/docker-gc
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc spotify/docker-gc
 ```


### PR DESCRIPTION
Fix part of #44 
Add /etc volume which contains user-defined configuration files