### PR TITLE
Docker version 1.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM gliderlabs/alpine:3.2
 
-ENV DOCKER_VERSION 1.6.2
+ENV DOCKER_VERSION 1.8.2
 
 # We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it
 RUN apk --update add bash curl python \


### PR DESCRIPTION
Bump Docker version to latest stable.

```sh
$ docker run -ti --rm -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc spotify/docker-gc sh
/ # docker version
Client:
 Version:      1.8.2
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   0a8c2e3
 Built:        Thu Sep 10 19:10:10 UTC 2015
 OS/Arch:      linux/amd64

Server:
 Version:      1.9.0-dev
 API version:  1.21
 Go version:   go1.4.2
 Git commit:   02ae137
 Built:        Fri Sep 25 17:37:00 UTC 2015
 OS/Arch:      linux/amd64
 Experimental: true
/ #
```

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>