### PR TITLE
Issue55 logging

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -224,11 +224,11 @@ done
 comm -23 images.reap.tmp images.used | grep -v -f $EXCLUDE_IDS_FILE > images.reap || true
 
 # Reap containers.
-xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
 echo "[$(date)] Containers removed " >> "$LOG"
 container_log containers.reap
+xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
 
 # Reap images.
-xargs -n 1 $DOCKER rmi < images.reap &>/dev/null || true
 echo "[$(date)] Images removed" >> "$LOG"
 image_log images.reap
+xargs -n 1 $DOCKER rmi < images.reap &>/dev/null || true

--- a/docker-gc
+++ b/docker-gc
@@ -38,6 +38,7 @@ set -o errexit
 
 GRACE_PERIOD_SECONDS=${GRACE_PERIOD_SECONDS:=3600}
 STATE_DIR=${STATE_DIR:=/var/lib/docker-gc}
+LOG=${LOG:=$STATE_DIR/docker-dc.log}
 DOCKER=${DOCKER:=docker}
 PID_DIR=${PID_DIR:=/var/run}
 
@@ -154,6 +155,11 @@ $DOCKER ps -a -q --no-trunc | sort | uniq > containers.all
 
 # List running containers
 $DOCKER ps -q --no-trunc | sort | uniq > containers.running
+echo "[$(date)] Containers running" >> "$LOG"
+cat containers.running | while read line
+do
+    echo "$line $(docker inspect -f {{.Name}} $line)" | tr -d '/' >> "$LOG"
+done
 
 # compute ids of container images to exclude from GC
 compute_exclude_ids
@@ -163,6 +169,11 @@ compute_exclude_container_ids
 
 # List containers that are not running
 comm -23 containers.all containers.running > containers.exited
+echo "[$(date)] Containers not running" >> "$LOG"
+cat containers.exited | while read line
+do
+    echo "$line $(docker inspect -f {{.Name}} $line)" | tr -d '/' >> "$LOG"
+done
 
 # Find exited containers that finished at least GRACE_PERIOD_SECONDS ago
 echo -n "" > containers.reap.tmp
@@ -206,6 +217,16 @@ comm -23 images.reap.tmp images.used | grep -v -f $EXCLUDE_IDS_FILE > images.rea
 
 # Reap containers.
 xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
+echo "[$(date)] Containers removed " >> "$LOG"
+cat containers.reap | while read line
+do
+    echo "$line $(docker inspect -f {{.Name}} $line)" | tr -d '/' >> "$LOG"
+done
 
 # Reap images.
 xargs -n 1 $DOCKER rmi < images.reap &>/dev/null || true
+echo "[$(date)] Images removed" >> "$LOG"
+cat images.reap | while read line
+do
+    echo "$line $(docker inspect -f {{.Tags}} $line)" | tr -d '\[]' >> "$LOG"
+done

--- a/docker-gc
+++ b/docker-gc
@@ -170,10 +170,7 @@ $DOCKER ps -a -q --no-trunc | sort | uniq > containers.all
 # List running containers
 $DOCKER ps -q --no-trunc | sort | uniq > containers.running
 echo "[$(date)] Containers running" >> "$LOG"
-cat containers.running | while read line
-do
-    echo "$line $(docker inspect -f {{.Name}} $line)" | tr -d '/' >> "$LOG"
-done
+container_log containers.running
 
 # compute ids of container images to exclude from GC
 compute_exclude_ids

--- a/docker-gc
+++ b/docker-gc
@@ -140,6 +140,20 @@ function compute_exclude_container_ids() {
         | sort -u > $EXCLUDE_CONTAINER_IDS_FILE
 }
 
+function container_log() {
+    cat $1 | while read line
+    do
+        echo "$line $(docker inspect -f {{.Name}} $line)" | tr -d '/' >> "$LOG"
+    done
+}
+
+function image_log() {
+    cat $1 | while read line
+    do
+        echo "$line $(docker inspect -f {{.Tags}} $line)" | tr -d '\[]' >> "$LOG"
+    done
+}
+
 # Change into the state directory (and create it if it doesn't exist)
 if [ ! -d "$STATE_DIR" ]
 then
@@ -170,10 +184,7 @@ compute_exclude_container_ids
 # List containers that are not running
 comm -23 containers.all containers.running > containers.exited
 echo "[$(date)] Containers not running" >> "$LOG"
-cat containers.exited | while read line
-do
-    echo "$line $(docker inspect -f {{.Name}} $line)" | tr -d '/' >> "$LOG"
-done
+container_log containers.exited
 
 # Find exited containers that finished at least GRACE_PERIOD_SECONDS ago
 echo -n "" > containers.reap.tmp
@@ -218,15 +229,9 @@ comm -23 images.reap.tmp images.used | grep -v -f $EXCLUDE_IDS_FILE > images.rea
 # Reap containers.
 xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
 echo "[$(date)] Containers removed " >> "$LOG"
-cat containers.reap | while read line
-do
-    echo "$line $(docker inspect -f {{.Name}} $line)" | tr -d '/' >> "$LOG"
-done
+container_log containers.reap
 
 # Reap images.
 xargs -n 1 $DOCKER rmi < images.reap &>/dev/null || true
 echo "[$(date)] Images removed" >> "$LOG"
-cat images.reap | while read line
-do
-    echo "$line $(docker inspect -f {{.Tags}} $line)" | tr -d '\[]' >> "$LOG"
-done
+image_log images.reap


### PR DESCRIPTION
Adds crude logging.

```sh
$ sudo bash docker-gc
$ cat /var/lib/docker-gc/docker-dc.log
[Mon Oct 12 23:47:28 CEST 2015] Containers running
[Mon Oct 12 23:47:28 CEST 2015] Containers not running
773ab1faa41f647aae6739fcb7f2767baa0fe7a15f2900050579dd3149d5bf35 goofy_swirles
edaacb0ded33ac7d5d0841f88cb3746a7c5f72a407059b33993409a633a4e82e ecstatic_almeida
[Mon Oct 12 23:47:29 CEST 2015] Containers removed
[Mon Oct 12 23:47:29 CEST 2015] Images removed
0f73ae75014f435e279d85ad31edc67e46c4a5d692b61840ff51e9d05f3b01ec centos:7 centos:latest
8a2b759d9dd8c31211ecddf456ea4e533edbe2275436f3baa79f524e6f824b5c oraclelinux:7 oraclelinux:latest
8c00acfb017549e44d28098762c3e6296872a1ca9b90385855f1019d84bb0dac debian:jessie debian:latest debian:8
921fca91e31ede9ad359e4940fbe4d3e63659ca1a8dcb0d18462ed21d39f4356 javaown:latest debian:java
d6b241b32a2ddad57e176640fc14b596e1945bc822396711877667f7bb388b43 opensuse:13.2 opensuse:latest
ded7cd95e059788f2586a51c275a4f151653779d6a7f4dad77c2bd34601d94e4 fedora:22 fedora:latest
f4fddc471ec22fc1f7d37768132f1753bc171121e30ac2af7fcb0302588197c0 alpine:3.2 alpine:latest
$
```

#55 
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>