### PR TITLE
Impose a minimum number of images to keep per repository

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -37,6 +37,7 @@ set -o nounset
 set -o errexit
 
 GRACE_PERIOD_SECONDS=${GRACE_PERIOD_SECONDS:=3600}
+MINIMUM_IMAGES_TO_SAVE=${MINIMUM_IMAGES_TO_SAVE:=10}
 STATE_DIR=${STATE_DIR:=/var/lib/docker-gc}
 DOCKER=${DOCKER:=docker}
 PID_DIR=${PID_DIR:=/var/run}
@@ -190,11 +191,18 @@ xargs -n 1 $DOCKER inspect -f '{{.Id}}' 2>/dev/null |
 sort | uniq > images.used
 
 # List images to reap; images that existed last run and are not in use.
-$DOCKER images -q --no-trunc | sort | uniq > images.all
+echo -n "" > images.all
+$DOCKER images | while read line
+do
+    awk '{print $1};'
+done | sort | uniq | while read line
+do
+    $DOCKER images -q --no-trunc $line | tail -n +$MINIMUM_IMAGES_TO_SAVE | sort | uniq >> images.all
+done
 
 # Find images that are created at least GRACE_PERIOD_SECONDS ago
 echo -n "" > images.reap.tmp
-cat images.all | while read line
+cat images.all | sort | uniq | while read line
 do
     CREATED=$(${DOCKER} inspect -f "{{.Created}}" ${line})
     ELAPSED=$(elapsed_time $CREATED)
@@ -209,3 +217,4 @@ xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
 
 # Reap images.
 xargs -n 1 $DOCKER rmi < images.reap &>/dev/null || true
+


### PR DESCRIPTION
Hello team Spotify!

This is a change we are exploring to always keep the last 10 image for each repository. Our goal is to be able to switch to the previous version quickly when something goes wrong.

Would this be a useful change for you? I will be happy to build+test this change if you think it is interesting :-)

Thanks!
