### PR TITLE
remove python dependency from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gliderlabs/alpine:3.2
 ENV DOCKER_VERSION 1.6.2
 
 # We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it
-RUN apk --update add bash curl python \
+RUN apk --update add bash curl \
   && curl -s https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} > /bin/docker \
   && chmod +x /bin/docker \
   && apk del curl \


### PR DESCRIPTION
No longer needed as of 6626033.

Fixes #61.