### PR TITLE
Add option to force delete images

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ mariadb-data
 drunk_goodall
 ```
 
+### Forcing deletion of images that have multiple tags
+
+By default, docker will not remove an image if it is tagged in multiple
+repositories.
+If you have a server running docker where this is the case, for example
+in CI environments where dockers are being built, re-tagged, and pushed,
+you can enable a force flag to override this default.
+
+```
+FORCE_IMAGE_REMOVAL=1 docker-gc
+```
+
 ## Running as a Docker Image
 
 A Dockerfile is provided as an alternative to a local installation. By default

--- a/docker-gc
+++ b/docker-gc
@@ -44,6 +44,7 @@ set -o errexit
 
 GRACE_PERIOD_SECONDS=${GRACE_PERIOD_SECONDS:=3600}
 STATE_DIR=${STATE_DIR:=/var/lib/docker-gc}
+FORCE_IMAGE_REMOVAL=${FORCE_IMAGE_REMOVAL:=0}
 DOCKER=${DOCKER:=docker}
 PID_DIR=${PID_DIR:=/var/run}
 LOG_TO_SYSLOG=${LOG_TO_SYSLOG:=0}
@@ -249,6 +250,12 @@ comm -23 images.reap.tmp images.used | grep -v -f $EXCLUDE_IDS_FILE > images.rea
 container_log "Container removed" containers.reap
 xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
 
+# Use -f flag on docker rmi command; forces removal of images that have multiple tags
+FORCE_FLAG=""
+if [[ $FORCE_IMAGE_REMOVAL -gt 0 ]]; then
+    FORCE_FLAG="-f"
+fi
+
 # Reap images.
 image_log "Removing image" images.reap
-xargs -n 1 $DOCKER rmi < images.reap &>/dev/null || true
+xargs -n 1 $DOCKER rmi $FORCE_FLAG < images.reap &>/dev/null || true


### PR DESCRIPTION
This PR adds an env flag, `FORCE_FLAG` which can be set to force deletion of images that are tagged in multiple repositories.
It does so by enabling the `-f` flag on the `docker rmi` command.

As stated in the readme, this is useful when a CI node has the job of pulling, re-tagging, and pushing images.

Fixes issue #15 