### PR TITLE
add dead containers to containers.dead

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -206,6 +206,7 @@ comm -23 containers.all containers.running > containers.exited
 container_log "Container not running" containers.exited
 
 # List all dead containers
+echo -n "" > containers.dead
 cat containers.all | while read line
 do
     DEAD=$(${DOCKER} inspect -f "{{.State.Dead}}" ${line})
@@ -213,6 +214,7 @@ do
         echo $line >> containers.dead
     fi
 done
+container_log "Container in a dead state" containers.dead
 
 # Find exited containers that finished at least GRACE_PERIOD_SECONDS ago
 echo -n "" > containers.reap.tmp

--- a/docker-gc
+++ b/docker-gc
@@ -205,6 +205,15 @@ compute_exclude_container_ids
 comm -23 containers.all containers.running > containers.exited
 container_log "Container not running" containers.exited
 
+# List all dead containers
+cat containers.all | while read line
+do
+    DEAD=$(${DOCKER} inspect -f "{{.State.Dead}}" ${line})
+    if [ "$DEAD" = "true" ]; then
+        echo $line >> containers.dead
+    fi
+done
+
 # Find exited containers that finished at least GRACE_PERIOD_SECONDS ago
 echo -n "" > containers.reap.tmp
 cat containers.exited | while read line


### PR DESCRIPTION
Since the dead state is kinda odd, don't remove the container and instead append `containers.dead` for manual cleaning.

Closes #60 

Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
