### PR TITLE
Docs: Add example exclude entry matching all tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ which is 12.
 An example image excludes file might contain:
 ```
 spotify/cassandra:latest
+redis:[^ ]\+
 9681260c3ad5
 ```
 


### PR DESCRIPTION
There was no example of the match pattern used other than "patterns (in the `grep` sense)", which tripped me up as I was using unescaped `+` in my patterns which didn't match anything. An example here should help avoid others' confusion :smile: