### PR TITLE
To build the package build-essential is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ container (see [below](#running-as-a-docker-container)).
 
 
 ```sh
-$ apt-get install git devscripts debhelper
+$ apt-get install git devscripts debhelper build-essential
 $ git clone https://github.com/spotify/docker-gc.git
 $ cd docker-gc
 $ debuild -us -uc -b


### PR DESCRIPTION
When building on Ubuntu Trusty box I also needed to install build-essential, otherwise I got the error:

    dpkg-checkbuilddeps: Unmet build dependencies: build-essential:native