### PR TITLE
Add flag to allow forcing container removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ you can enable a force flag to override this default.
 FORCE_IMAGE_REMOVAL=1 docker-gc
 ```
 
+### Forcing deletion of containers
+
+By default, if an error is encountered when cleaning up a container, Docker
+will report the error back and leave it on disk.  This can sometimes lead to
+containers accumulating.  If you run into this issue, you can force the removal
+of the container by setting the environment variable below:
+
+```
+FORCE_CONTAINER_REMOVAL=1 docker-dc
+```
+
 ### Excluding Recently Exited Containers and Images From Garbage Collection
 
 By default, docker-gc will not remove a container if it exited less than 3600 seconds (1 hour) ago. In some cases you might need to change this setting (e.g. you need exited containers to stick around for debugging for several days). Set the `GRACE_PERIOD_SECONDS` variable to override this default.

--- a/docker-gc
+++ b/docker-gc
@@ -44,6 +44,7 @@ set -o errexit
 
 GRACE_PERIOD_SECONDS=${GRACE_PERIOD_SECONDS:=3600}
 STATE_DIR=${STATE_DIR:=/var/lib/docker-gc}
+FORCE_CONTAINER_REMOVAL=${FORCE_CONTAINER_REMOVAL:=0}
 FORCE_IMAGE_REMOVAL=${FORCE_IMAGE_REMOVAL:=0}
 DOCKER=${DOCKER:=docker}
 PID_DIR=${PID_DIR:=/var/run}
@@ -243,16 +244,22 @@ do
 done
 comm -23 images.reap.tmp images.used | grep -v -f $EXCLUDE_IDS_FILE > images.reap || true
 
+# Use -f flag on docker rm command; forces removal of images that are in Dead
+# status or give errors when removing.
+FORCE_CONTAINER_FLAG=""
+if [[ $FORCE_CONTAINER_REMOVAL -gt 0 ]]; then
+    FORCE_CONTAINER_FLAG="-f"
+fi
 # Reap containers.
 container_log "Container removed" containers.reap
-xargs -n 1 $DOCKER rm --volumes=true < containers.reap &>/dev/null || true
+xargs -n 1 $DOCKER rm $FORCE_CONTAINER_FLAG --volumes=true < containers.reap &>/dev/null || true
 
 # Use -f flag on docker rmi command; forces removal of images that have multiple tags
-FORCE_FLAG=""
+FORCE_IMAGE_FLAG=""
 if [[ $FORCE_IMAGE_REMOVAL -gt 0 ]]; then
-    FORCE_FLAG="-f"
+    FORCE_IMAGE_FLAG="-f"
 fi
 
 # Reap images.
 image_log "Removing image" images.reap
-xargs -n 1 $DOCKER rmi $FORCE_FLAG < images.reap &>/dev/null || true
+xargs -n 1 $DOCKER rmi $FORCE_IMAGE_FLAG < images.reap &>/dev/null || true


### PR DESCRIPTION
This adds another environment variable flag to allow passing in -f to
the docker rm command when removing the container.  If you're running
into issues with getting errors on removing containers, this ensures
they still get cleaned up.