### PR TITLE
Use flock to ensure exclusivity

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -52,18 +52,17 @@ LOG_TO_SYSLOG=${LOG_TO_SYSLOG:=0}
 SYSLOG_FACILITY=${SYSLOG_FACILITY:=user}
 SYSLOG_LEVEL=${SYSLOG_LEVEL:=info}
 SYSLOG_TAG=${SYSLOG_TAG:=docker-gc}
+PIDFILE=$PID_DIR/dockergc
 
-for pid in $(pidof -s docker-gc); do
-    if [[ $pid != $$ ]]; then
-        echo "[$(date)] : docker-gc : Process is already running with PID $pid"
-        exit 1
-    fi
-done
+exec 3>>$PIDFILE
+if ! flock -x -n 3; then
+  echo "[$(date)] : docker-gc : Process is already running"
+  exit 1
+fi
 
-trap "rm -f -- '$PID_DIR/dockergc'" EXIT
+trap "rm -f -- '$PIDFILE'" EXIT
 
-echo $$ > $PID_DIR/dockergc
-
+echo $$ > $PIDFILE
 
 EXCLUDE_FROM_GC=${EXCLUDE_FROM_GC:=/etc/docker-gc-exclude}
 if [ ! -f "$EXCLUDE_FROM_GC" ]


### PR DESCRIPTION
The pidof method currently employed does not ensure exclusivity as pidof will not use argv[1] to find matching processes unless -x flag is supplied (at least on Ubuntu Trusty and Wily, result may vary depending on your distro and sysvinit version). Secondly, the current implementation assumes the name of the process to be docker-gc, which may not be correct if the user has named the executable something else.

This replaces the pidof implementation with one using flock.
