### PR TITLE
Do not remove images that did not exist in the last run

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -231,11 +231,15 @@ xargs -n 1 $DOCKER inspect -f '{{.Image}}' 2>/dev/null |
 sort | uniq > images.used
 
 # List images to reap; images that existed last run and are not in use.
+echo -n "" > images.last-run
+if [ -f images.all ]; then
+    cat images.all > images.last-run
+fi
 $DOCKER images -q --no-trunc | sort | uniq > images.all
 
 # Find images that are created at least GRACE_PERIOD_SECONDS ago
 echo -n "" > images.reap.tmp
-cat images.all | while read line
+comm -23 images.last-run images.all | while read line
 do
     CREATED=$(${DOCKER} inspect -f "{{.Created}}" ${line})
     ELAPSED=$(elapsed_time $CREATED)


### PR DESCRIPTION
If an image did not exist in the last run then it may have just been created.

If the image has just been created and we remove it then we might encounter:

https://github.com/spotify/docker-gc/issues/43

There are two outstanding issues related to #43

1. It is stated in https://github.com/docker/docker/issues/8926#issuecomment-167855036 that the fix while applicable to `docker pull` may not fix the issue for `docker build`
2. The fix for https://github.com/docker/docker/issues/8926 has not been back ported to Docker 1.7.1 (the last version of Docker supported on RHEL 6)

While most people do not care about (2), (1) may still be an issue.