### PR TITLE
remove sha256 for docker version 1.10

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -231,7 +231,7 @@ xargs -n 1 $DOCKER inspect -f '{{.Image}}' 2>/dev/null |
 sort | uniq > images.used
 
 # List images to reap; images that existed last run and are not in use.
-$DOCKER images -q --no-trunc | sort | uniq > images.all
+$DOCKER images -q --no-trunc | sed 's/sha256://' | sort | uniq > images.all
 
 # Find images that are created at least GRACE_PERIOD_SECONDS ago
 echo -n "" > images.reap.tmp


### PR DESCRIPTION
Initially thought https://github.com/spotify/docker-gc/pull/93 would fix this issue but after some testing realized it does not. 

When running `docker images -q --no-trunc | sed 's/[^:]\+://' | sort | uniq`  the expected output is only the image ids but the actual result is 
```bash
bash-4.3# docker images -q --no-trunc | sed 's/[^:]\+://' | sort | uniq
sha256:080defdf80d7e14d4ae2d23c00e51c1ed31103c80fafd5eba71eeae463e49c78
sha256:790bffac55a993594b4e8f7b8ea73b6e2e90891394df1bcfb2d74ce669a0bd46
sha256:7a0dbfde8b8c592e6507117bd29b84a4ebc3f7c8e7dfa76b1d955c5606f51c59
sha256:87de034ee215ed7d59762748f3c9ebfa9a968f554dd00219f59ede912524d690
sha256:91c8d5fe5cb66e029e7b92155f53fa3eafa4c7d2cf4a1f369b5e112f27dd10f0
sha256:b72889fa879c08b224cc33d260c434ec6295b56c7677b5ff6213b5296df31aaf
sha256:f7ea1616029fbe082b17305330b7240431700863aae48e3080f314575499c7db
sha256:fa99e0a62cc44e22eb6e0057d4d04df9ffe9541e716db91724a244be8ad4535b
```
