### PR TITLE
Replace example grep pattern by a working pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ which is 12.
 An example image excludes file might contain:
 ```
 spotify/cassandra:latest
-redis:[^ ]\+
+redis:.*
 9681260c3ad5
 ```
 


### PR DESCRIPTION
The problem I was running into, with the spotify docker from dockerhub, was that I had a pattern set in my docker exclude file for (for example) ruby:
`ruby:[^ ]\+`
But the ruby images were getting cleaned up regardless.

It looks like an alpine kind of thing, I tested the code on a few different places (Mac, Debian) where it worked as you'd expect. However, when using Alpine Linux, `[^ ]\+` did not return any IDs and cleaned up images I didn't want it to clean up.