### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,14 @@ ENV DOCKER_VERSION 1.6.2
 
 # We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it
 RUN apk --update add bash curl \
-  && curl -s https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} > /bin/docker \
-  && chmod +x /bin/docker \
+  && cd /tmp/ \
+  && curl -sSL -O https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz \
+  && tar zxf docker-${DOCKER_VERSION}.tgz \
+  && mkdir -p /usr/local/bin/ \
+  && mv $(find -name 'docker') /usr/local/bin/ \
+  && chmod +x /usr/local/bin/docker \
   && apk del curl \
+  && rm -rf /tmp/* \
   && rm -rf /var/cache/apk/*
 
 COPY ./docker-gc /docker-gc


### PR DESCRIPTION
At least now, files are now .tgz (including 1.6.2 that is the default).
Otherwise, an image is downloaded that is shown on 404 as the requested file
does not exist.

Also, the layout on the tgz has changed, so it is adapted from the new layout.