### PR TITLE
Make it clear that the docker image is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ DRY_RUN=1 docker-gc
 A Dockerfile is provided as an alternative to a local installation. By default
 the container will start up, run a single garbage collection, and shut down.
 
+The image is published as `spotify/docker-gc`.
+
 #### Building the Docker Image
 The image is currently built with Docker 1.6.2, but to build it against a newer
 Docker version (to ensure that the API version of the command-line interface


### PR DESCRIPTION
It's not clear that the image is published, and you don't have to build it yourself. 