### PR TITLE
Add dh-make to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ container (see [below](#running-as-a-docker-container)).
 
 
 ```sh
-$ apt-get install git devscripts debhelper build-essential
+$ apt-get install git devscripts debhelper build-essential dh-make
 $ git clone https://github.com/spotify/docker-gc.git
 $ cd docker-gc
 $ debuild -us -uc -b


### PR DESCRIPTION
You may need dh-make to build a .deb package, otherwise you would get a "dh: Command not found" error.