### PR TITLE
Fix bug of detecting exist process

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -54,7 +54,7 @@ SYSLOG_LEVEL=${SYSLOG_LEVEL:=info}
 SYSLOG_TAG=${SYSLOG_TAG:=docker-gc}
 DRY_RUN=${DRY_RUN:=0}
 
-for pid in $(pidof -s docker-gc); do
+for pid in $(pgrep -f docker-gc); do
     if [[ $pid != $$ ]]; then
         echo "[$(date)] : docker-gc : Process is already running with PID $pid"
         exit 1


### PR DESCRIPTION
# Description
There might be some mistake in detecting exist docker-gc process.
First of all, if you use "pidof -s program", you will get just one pid, eg:

> root@hzwangxing01:~/go/src/docker-gc# sleep 100 &
[1] 12945
root@hzwangxing01:~/go/src/docker-gc# sleep 100 &
[2] 12946
root@hzwangxing01:~/go/src/docker-gc# sleep 100 &
[3] 12947
root@hzwangxing01:~/go/src/docker-gc# pidof -s sleep
12947
root@hzwangxing01:~/go/src/docker-gc# pidof sleep
12947 12946 12945

Secondly, pidof won't take effect if program is started by bash, eg:

> root@hzwangxing01:~/go/src/docker-gc# ps -ef | grep docker-gc | grep -v grep
root     13090 26069  0 11:47 pts/1    00:00:00 /bin/bash ./docker-gc
root@hzwangxing01:~/go/src/docker-gc# pidof docker-gc
root@hzwangxing01:~/go/src/docker-gc# pidof bash
26069 13090 11706 10666

So I use pgrep instead.