### PR TITLE
Added support for missing -s option of pidof on MacOS

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -54,7 +54,8 @@ SYSLOG_LEVEL=${SYSLOG_LEVEL:=info}
 SYSLOG_TAG=${SYSLOG_TAG:=docker-gc}
 DRY_RUN=${DRY_RUN:=0}
 
-for pid in $(pidof docker-gc | awk '{print $1}'); do
+
+for pid in $(pgrep -f 'docker-gc'); do
     if [[ $pid != $$ ]]; then
         echo "[$(date)] : docker-gc : Process is already running with PID $pid"
         exit 1

--- a/docker-gc
+++ b/docker-gc
@@ -54,7 +54,7 @@ SYSLOG_LEVEL=${SYSLOG_LEVEL:=info}
 SYSLOG_TAG=${SYSLOG_TAG:=docker-gc}
 DRY_RUN=${DRY_RUN:=0}
 
-for pid in $(pidof -s docker-gc); do
+for pid in $(pidof docker-gc | awk '{print $1}'); do
     if [[ $pid != $$ ]]; then
         echo "[$(date)] : docker-gc : Process is already running with PID $pid"
         exit 1


### PR DESCRIPTION
As we have docker beta available natively for MacOS it would be nice to be able to run GC collector directly on MacOS. This pull request fixes missing `-s` option to pidof on MacOS.
