### PR TITLE
Add flag to not garbage collect any containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ mariadb-data
 drunk_goodall
 ```
 
+If you would prefer to not garbage collect any containers at all then
+you can do this by setting the environment variable below:
+
+```
+REMOVE_CONTAINERS=0 docker-gc
+```
+
 ### Forcing deletion of images that have multiple tags
 
 By default, docker will not remove an image if it is tagged in multiple

--- a/docker-gc
+++ b/docker-gc
@@ -44,6 +44,7 @@ set -o errexit
 
 GRACE_PERIOD_SECONDS=${GRACE_PERIOD_SECONDS:=3600}
 STATE_DIR=${STATE_DIR:=/var/lib/docker-gc}
+REMOVE_CONTAINERS=${REMOVE_CONTAINERS:=1}
 FORCE_CONTAINER_REMOVAL=${FORCE_CONTAINER_REMOVAL:=0}
 FORCE_IMAGE_REMOVAL=${FORCE_IMAGE_REMOVAL:=0}
 DOCKER=${DOCKER:=docker}
@@ -252,11 +253,13 @@ if [[ $FORCE_CONTAINER_REMOVAL -gt 0 ]]; then
     FORCE_CONTAINER_FLAG="-f"
 fi
 # Reap containers.
-if [[ $DRY_RUN -gt 0 ]]; then
-    container_log "The following container would have been removed" containers.reap
-else
-    container_log "Removing containers" containers.reap
-    xargs -n 1 $DOCKER rm $FORCE_CONTAINER_FLAG --volumes=true < containers.reap &>/dev/null || true
+if [[ $REMOVE_CONTAINERS -gt 0 ]]; then
+  if [[ $DRY_RUN -gt 0 ]]; then
+      container_log "The following container would have been removed" containers.reap
+  else
+      container_log "Removing containers" containers.reap
+      xargs -n 1 $DOCKER rm $FORCE_CONTAINER_FLAG --volumes=true < containers.reap &>/dev/null || true
+  fi
 fi
 
 # Use -f flag on docker rmi command; forces removal of images that have multiple tags


### PR DESCRIPTION
If the user would prefer to not garbage collect any containers then specify environment variable:
```
REMOVE_CONTAINERS=1
```

This is useful specifically in an environment such as Amazon ECS whereby containers are already cleaned up (and removal of them by another service causes issues) but images are not.

https://github.com/aws/amazon-ecs-agent/issues/364
https://github.com/aws/amazon-ecs-agent/issues/118