### PR TITLE
Added 'EXCLUDE_BY_LABEL' for container/image

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ By default, docker-gc will proceed with deletion of containers and images. To te
 DRY_RUN=1 docker-gc
 ```
 
+### Exclude by label
+You exclude containers and images having a certain label by setting the `EXCLUDE_BY_LABEL` variable.
+
+Example: ignore any containers or images labeled with 'docker-gc-ignore'
+```
+EXCLUDE_BY_LABEL=docker-gc-ignore
+```
+
 
 ## Running as a Docker Image
 

--- a/docker-gc
+++ b/docker-gc
@@ -54,6 +54,7 @@ SYSLOG_LEVEL=${SYSLOG_LEVEL:=info}
 SYSLOG_TAG=${SYSLOG_TAG:=docker-gc}
 DRY_RUN=${DRY_RUN:=0}
 EXCLUDE_DEAD=${EXCLUDE_DEAD:=0}
+EXCLUDE_BY_LABEL=${EXCLUDE_BY_LABEL:=''}
 
 for pid in $(pidof -s docker-gc); do
     if [[ $pid != $$ ]]; then
@@ -260,6 +261,15 @@ FORCE_CONTAINER_FLAG=""
 if [[ $FORCE_CONTAINER_REMOVAL -gt 0 ]]; then
     FORCE_CONTAINER_FLAG="-f"
 fi
+
+# Exclude containers by label
+if [[ ! -z "${EXCLUDE_BY_LABEL// }" ]]; then
+    $DOCKER ps -q -a --no-trunc --filter "label=${EXCLUDE_BY_LABEL}" | sort | uniq > containers.excluded
+    container_log "The following container was excluded from removal by label '${EXCLUDE_BY_LABEL}'" containers.excluded
+    cat containers.reap | grep -v -f containers.excluded > containers.reap.tmp
+    mv -f containers.reap.tmp containers.reap
+fi
+
 # Reap containers.
 if [[ $DRY_RUN -gt 0 ]]; then
     container_log "The following container would have been removed" containers.reap
@@ -274,6 +284,14 @@ if [[ $FORCE_IMAGE_REMOVAL -gt 0 ]]; then
     FORCE_IMAGE_FLAG="-f"
 fi
 
+# Exclude images by label
+if [[ ! -z "${EXCLUDE_BY_LABEL// }" ]]; then
+    $DOCKER images -q --no-trunc --filter "label=${EXCLUDE_BY_LABEL}" | sort | uniq > images.excluded
+    image_log "The following image was excluded from removal by label '${EXCLUDE_BY_LABEL}'" images.excluded
+    cat images.reap | grep -v -f images.excluded > images.reap.tmp
+    mv -f images.reap.tmp images.reap
+fi
+
 # Reap images.
 if [[ $DRY_RUN -gt 0 ]]; then
     image_log "The following image would have been removed" images.reap
@@ -281,4 +299,3 @@ else
     image_log "Removing image" images.reap
     xargs -n 1 $DOCKER rmi $FORCE_IMAGE_FLAG < images.reap &>/dev/null || true
 fi
-


### PR DESCRIPTION
Allows specifying of a label to be explicitly excluded by docker-gc for containers or images.  This way the white-listing process can be delegated to creators of images/containers (if they don't happen to be the same people who run docker-gc on the host).