### PR TITLE
GH-127 Prevent deleting created state containers

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -222,7 +222,10 @@ container_log "Container not running" containers.exited
 cat containers.exited | while read line
 do
     EXITED=$(${DOCKER} inspect -f "{{json .State.FinishedAt}}" ${line})
-    ELAPSED=$(elapsed_time $EXITED)
+    CREATED=$(${DOCKER} inspect -f "{{json .Created}}" ${line})
+    ELAPSED_EXITED=$(elapsed_time $EXITED)
+    ELAPSED_CREATED=$(elapsed_time $CREATED)
+    ELAPSED=$( (( $ELAPSED_EXITED >= $ELAPSED_CREATED )) && echo "$ELAPSED_EXITED" || echo "$ELAPSED_CREATED" )
     if [[ $ELAPSED -gt $GRACE_PERIOD_SECONDS ]]; then
         echo $line >> containers.reap.tmp
     fi

--- a/docker-gc
+++ b/docker-gc
@@ -225,7 +225,7 @@ do
     CREATED=$(${DOCKER} inspect -f "{{json .Created}}" ${line})
     ELAPSED_EXITED=$(elapsed_time $EXITED)
     ELAPSED_CREATED=$(elapsed_time $CREATED)
-    ELAPSED=$( (( $ELAPSED_EXITED >= $ELAPSED_CREATED )) && echo "$ELAPSED_EXITED" || echo "$ELAPSED_CREATED" )
+    ELAPSED=$( (( $ELAPSED_EXITED <= $ELAPSED_CREATED )) && echo "$ELAPSED_EXITED" || echo "$ELAPSED_CREATED" )
     if [[ $ELAPSED -gt $GRACE_PERIOD_SECONDS ]]; then
         echo $line >> containers.reap.tmp
     fi


### PR DESCRIPTION
This is for issue GH-127.

A clunky check to make sure the elapsed time on the finish isn't greater than the creation date.  This indicates the container was created, but not started.  In that case, use the creation date for the grace period reaping. 