### PR TITLE
Fix install docker 1.11+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --update add bash curl \
   && curl -sSL -O https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz \
   && tar zxf docker-${DOCKER_VERSION}.tgz \
   && mkdir -p /usr/local/bin/ \
-  && mv $(find -name 'docker') /usr/local/bin/ \
+  && mv $(find -name 'docker' -type f) /usr/local/bin/ \
   && chmod +x /usr/local/bin/docker \
   && apk del curl \
   && rm -rf /tmp/* \


### PR DESCRIPTION
Binaries archive of Docker 1.11+ contains not only binary named docker but folder with the same name and 3 other binaries, not used by docker-gc.

Without fix building docker container stops with error:
`mv: can't rename './docker/docker': No such file or directory`
