### PR TITLE
Set PATH to avoid `pidof command not found` report

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -55,7 +55,7 @@ SYSLOG_TAG=${SYSLOG_TAG:=docker-gc}
 DRY_RUN=${DRY_RUN:=0}
 EXCLUDE_DEAD=${EXCLUDE_DEAD:=0}
 
-for pid in $(pidof -s docker-gc); do
+for pid in $(/sbin/pidof -s docker-gc); do
     if [[ $pid != $$ ]]; then
         echo "[$(date)] : docker-gc : Process is already running with PID $pid"
         exit 1


### PR DESCRIPTION
It can fix [issue#133](https://github.com/spotify/docker-gc/issues/133). When docker-gc script run as a cron job,there is a report that is `pidof: command not found`
