### PR TITLE
build noarch rpms

### DIFF
--- a/rpm/docker-gc.spec
+++ b/rpm/docker-gc.spec
@@ -2,6 +2,7 @@ Name: docker-gc
 Version: 0.1.0
 Release: 1%{?dist}
 Summary: Docker garbage collection of containers and images.
+BuildArch: noarch
 
 License: Apache
 


### PR DESCRIPTION
Since `docker-gc` is an architecture independent shell script it makes sense to build `noarch` rpms.

Thank you!
