### PR TITLE
no containers are removed when EXCLUDE_DEAD = 1

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -211,8 +211,9 @@ comm -23 containers.all containers.running > containers.exited
 if [[ $EXCLUDE_DEAD -gt 0 ]]; then
     echo "Excluding dead containers"
     # List dead containers
-    $DOCKER ps -q -a -f status=dead | sort | uniq > containers.dead
-    comm -23 containers.exited containers.dead > containers.exited
+    $DOCKER ps -q -a -f status=dead | sort | uniq > containers.dead    
+    comm -23 containers.exited containers.dead > containers.exited.tmp
+    cat containers.exited.tmp > containers.exited
 fi
 
 container_log "Container not running" containers.exited


### PR DESCRIPTION
We need a containers.exited.tmp file because if you put the source-file as the output-file the result will (depending on bash?) be an empty file.

Bad:
```bash
$cat containers.exited 
123
456
789
$ cat containers.dead 
789
$ comm -23 containers.exited containers.dead > containers.exited
$ cat containers.exited
(empty file)
```
Good:
```
$comm -23 containers.exited containers.dead > containers.exited_tmp
$cat containers.exited_tmp
123
456
```