### PR TITLE
Add archlinux PKGBUILD script and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# ignore pacman build artifacts
+/pacman/pkg/*
+/pacman/src/*
+/pacman/docker-gc/*
+/pacman/*.tar.xz

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ To test that the job will actually run you can use this command
 run-parts --test /etc/cron.hourly
 ```
 
+## Building the Pacman Package
+
+
+```sh
+$ git clone https://github.com/spotify/docker-gc.git
+$ cd docker-gc/pacman
+$ makepkg -s
+```
+
+## Installing the Pacman Package
+
+```sh
+$ pacman -U docker-gc_0.0.4-1.tar.xz
+```
+
+This installs the `docker-gc` script into `/usr/bin`. Since `/usr/sbin` is a
+link to `/usr/bin` in archlinux you can follow the cron instructions from the
+debian section.
+
 ## Manual Usage
 
 To use the script manually, run `docker-gc`. The system user under

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Spotify
+# Contributor: Markus Plangg <mksplg at gmail dot com> via aur
+# Contributor: Bram Swenson <bram at craniumisajar dot com> 
+pkgname=docker-gc
+pkgver="0.1.1.$(git rev-parse --short HEAD)"
+pkgrel=1
+pkgdesc='A simple Docker container and image garbage collection script'
+arch=('any')
+url='https://github.com/spotify/docker-gc'
+license=('Apache')
+provides=("${pkgname}")
+conflicts=("${pkgname%-git}")
+source=('git+https://github.com/spotify/docker-gc.git')
+md5sums=('SKIP')
+
+depends=('bash')
+makedepends=('git')
+
+pkgver() {
+  cd "$srcdir/${pkgname}"
+  printf "0.1.1.%s" "$(git rev-parse --short HEAD)"
+}
+
+package() {
+  install -D -m755 "${pkgname}"/docker-gc "${pkgdir}/usr/bin/docker-gc"
+  install -d -m755 "${pkgdir}"/var/lib/docker-gc
+}


### PR DESCRIPTION
Pretty sure this is setup in such a way that it won't require maintenance until/if you all decide to start cutting formal releases. In which case the `pkgver` variable should be all that has to update. Thanks!