### PR TITLE
Add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ still on disk.
 This script is intended to be run as a cron job, but you can also run it as a Docker
 container (see [below](#running-as-a-docker-container)).
 
+## Using the install script
+This script installs the dependencies needed to build docker-gc, then adds docker-gc 
+as daily cron job. Finally, it tests wether it is installed successfully as cron job.  
+
+```sh
+curl -s https://raw.githubusercontent.com/RubieV/docker-gc/feature/install/install.sh | bash
+```
+
 ## Building the Debian Package
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+apt-get install git devscripts debhelper build-essential dh-make -y
+git clone https://github.com/spotify/docker-gc.git
+cd docker-gc
+debuild -us -uc -b
+
+dpkg -i ../docker-gc_*_all.deb
+
+cat > /etc/cron.daily/docker-gc << EOL
+#!/bin/bash
+/usr/sbin/docker-gc
+EOL
+
+chmod +x /etc/cron.daily/docker-gc
+
+if run-parts --test /etc/cron.daily/ | grep -q docker-gc; then
+  echo Setup correctly, docker-gc is executing daily
+else
+  echo Setup has not succeeded
+fi


### PR DESCRIPTION
To ease installation, added to the repo you can find an install.sh bash script. In the readme, a curl | bash oneliner is added.

After the merge has been completed, it might be cleaner to change the readme githubusercontent link that points to my fork and point it to the current repo.