### PR TITLE
Allow most recent n images to be preserved for a repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ you can enable a force flag to override this default.
 FORCE_IMAGE_REMOVAL=1 docker-gc
 ```
 
+### Preserving a minimum number of images for every repository
+
+You might want to always keep a set of the most recent images for any
+repository. For example, if you are continually rebuilding an image during
+development you would want to clear out all but the most recent version of an
+image. To do so, set the `MINIMUM_IMAGES_TO_SAVE=1` environment variable. You
+can preserve any count of the most recent images, e.g. save the most recent 10
+with `MINIMUM_IMAGES_TO_SAVE=10`.
+
 ### Forcing deletion of containers
 
 By default, if an error is encountered when cleaning up a container, Docker

--- a/docker-gc
+++ b/docker-gc
@@ -252,7 +252,6 @@ do
     | sort --key 2 --reverse \
     | tail --lines +$((MINIMUM_IMAGES_TO_SAVE+1)) \
     | cut --fields 1 --delimiter " " \
-    | sort \
     | uniq >> images.all
 done
 

--- a/docker-gc
+++ b/docker-gc
@@ -43,6 +43,7 @@ set -o nounset
 set -o errexit
 
 GRACE_PERIOD_SECONDS=${GRACE_PERIOD_SECONDS:=3600}
+MINIMUM_IMAGES_TO_SAVE=${MINIMUM_IMAGES_TO_SAVE:=0}
 STATE_DIR=${STATE_DIR:=/var/lib/docker-gc}
 FORCE_CONTAINER_REMOVAL=${FORCE_CONTAINER_REMOVAL:=0}
 FORCE_IMAGE_REMOVAL=${FORCE_IMAGE_REMOVAL:=0}
@@ -241,11 +242,23 @@ xargs -n 1 $DOCKER inspect -f '{{.Image}}' 2>/dev/null |
 sort | uniq > images.used
 
 # List images to reap; images that existed last run and are not in use.
-$DOCKER images -q --no-trunc | sort | uniq > images.all
+echo -n "" > images.all
+$DOCKER images | while read line
+do
+    awk '{print $1};'
+done | sort | uniq | while read line
+do
+  $DOCKER images --no-trunc --format "{{.ID}} {{.CreatedAt}}" $line \
+    | sort --key 2 --reverse \
+    | tail --lines +$((MINIMUM_IMAGES_TO_SAVE+1)) \
+    | cut --fields 1 --delimiter " " \
+    | sort \
+    | uniq >> images.all
+done
 
 # Find images that are created at least GRACE_PERIOD_SECONDS ago
 > images.reap.tmp
-cat images.all | while read line
+cat images.all | sort | uniq | while read line
 do
     CREATED=$(${DOCKER} inspect -f "{{.Created}}" ${line})
     ELAPSED=$(elapsed_time $CREATED)


### PR DESCRIPTION
This allows `MINIMUM_IMAGES_TO_SAVE=1` to be set to save the most recent
image for a repository. Any number of images can be saved, e.g. you can
save the most recent 10 images with `MINIMUM_IMAGES_TO_SAVE=10`.

For context, I'd like to use this on my development machine where I frequently
rebuild Docker images for a dozen or so repos. Those rebuilds are filling up my
disk, so I'd love to use `docker-gc` to clear up the images that I definitely won't
be using, while leaving the images I am using intact.

By default `MINIMUM_IMAGES_TO_SAVE` is set to 0, which keeps the behavior
of docker-gc the same as before this PR.

This work is based off of an [existing PR on this project](https://github.com/spotify/docker-gc/pull/57) that
seems to have been abandoned. The differences from the existing PR are:
  * Bases PR off of recent master
  * Fixes bugs in original PR that led to images being deleted when they should've been saved
  * Explicitly sorts images by their `CreatedAt` date rather then relying on the default output ordering of `docker images`
   * Defaults `MINIMUM_IMAGES_TO_SAVE` to 0 to preserve existing default behavior

Thanks!