### PR TITLE
Fix use of non-busybox opts to sort, tail and cut

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -249,9 +249,9 @@ do
 done | sort | uniq | while read line
 do
   $DOCKER images --no-trunc --format "{{.ID}} {{.CreatedAt}}" $line \
-    | sort --key 2 --reverse \
-    | tail --lines +$((MINIMUM_IMAGES_TO_SAVE+1)) \
-    | cut --fields 1 --delimiter " " \
+    | sort -k 2 -r \
+    | tail -n +$((MINIMUM_IMAGES_TO_SAVE+1)) \
+    | cut -f 1 -d " " \
     | uniq >> images.all
 done
 


### PR DESCRIPTION
`sort`, `tail` and `cut` use different command line options in Alpine than the normal `coreutils` ones, this PR changes them to use the correct opts. 

An alternate solution may be to install the `coreutils` package instead.

Broken in https://github.com/spotify/docker-gc/pull/162

Fixes https://github.com/spotify/docker-gc/issues/164

Tested running locally, errors previously logged are no longer returned. I could not run a `mvn clean test` as in the instructions though.

```
docker build -t local .
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock local
```

