### PR TITLE
Add dangling images to list of images.

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -255,6 +255,9 @@ do
     | uniq >> images.all
 done
 
+# Add dangling images to list.
+$DOCKER images --no-trunc --format "{{.ID}}" --filter dangling=true >> images.all
+
 # Find images that are created at least GRACE_PERIOD_SECONDS ago
 > images.reap.tmp
 cat images.all | sort | uniq | while read line


### PR DESCRIPTION
Because dangling images now show as `<none>:<none>` the original code for adding those images to the list of "all images" does not work anymore. This PR adds the IDs of the images marked as "dangling" (having no tag and not being part of any tagged images) to the list of images so that they are also checked against the list of running containers and expired like other images.