### PR TITLE
update sed commands in compute_exclude_ids

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -129,7 +129,7 @@ function compute_exclude_ids() {
         | sed 's/^\([^ ]*\) *\([^ ]*\) *\([^ ]*\).*/ \1:\2 \3 /' \
         | grep -f $PROCESSED_EXCLUDES 2>/dev/null \
         | cut -d' ' -f3 \
-        | sed 's/^/^(sha256:)?/' > $EXCLUDE_IDS_FILE
+        | sed 's/^/sha256:/' > $EXCLUDE_IDS_FILE
 }
 
 function compute_exclude_container_ids() {


### PR DESCRIPTION
We've found that the sed command in compute_exclude_ids function is in correct.
It should be modified like below:
sed 's/^/sha256:/' > $EXCLUDE_IDS_FILE
After modified, it works well.