### PR TITLE
Update README to match currently used docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ the container will start up, run a single garbage collection, and shut down.
 The image is published as `spotify/docker-gc`.
 
 #### Building the Docker Image
-The image is currently built with Docker 1.6.2, but to build it against a newer
+The image is currently built with Docker 1.12.4, but to build it against a newer
 Docker version (to ensure that the API version of the command-line interface
 matches with your Docker daemon), simply edit [the `ENV DOCKER_VERSION` line in
 `Dockerfile`][dockerfile-ENV] prior to the build step below.


### PR DESCRIPTION
The docker version used to build the image is no longer 1.6.2 but 1.12.4 since https://github.com/spotify/docker-gc/commit/0b367a428b3f97c42404489570a796c0f84ddd4f