### PR TITLE
Fix 'EXCLUDE_CONTAINER_IDS_FILE' will not be cleanup if 'EXCLUDE_CONTAINERS_FROM_GC' profile become empty.

### DIFF
--- a/docker-gc
+++ b/docker-gc
@@ -140,7 +140,7 @@ function compute_exclude_container_ids() {
         | sed -e 's/ /\|/g'`
     # The empty string would match everything
     if [ "$PROCESSED_EXCLUDES" = "" ]; then
-        touch $EXCLUDE_CONTAINER_IDS_FILE
+        > $EXCLUDE_CONTAINER_IDS_FILE
         return
     fi
     # Find all docker images


### PR DESCRIPTION
1. cleanup 'STATE_DIR' and show docker containers and images info.
\# rm -rf /var/lib/docker-gc/
\# docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
alpine              latest              7328f6f8b418        9 weeks ago         3.962 MB
\# docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                    PORTS               NAMES
95bebd030e6c        alpine              "sh"                16 hours ago        Exited (0) 16 hours ago                       focused_panini

2. find out containers and images can be deleted.
\# > /etc/docker-gc-exclude-containers
\# DRY_RUN=1 ./docker-gc
[2017-08-31T09:59:15] [INFO] : Container not running 95bebd030e6c1016314551c7966c8a5479cfc5a3005c8c5e8d4d4f1efe9df151 /focused_panini
[2017-08-31T09:59:15] [INFO] : The following container would have been removed 95bebd030e6c1016314551c7966c8a5479cfc5a3005c8c5e8d4d4f1efe9df151 /focused_panini
[2017-08-31T09:59:15] [INFO] : The following image would have been removed sha256:7328f6f8b41890597575cbaadc884e7386ae0acc53b747401ebce5cf0d624560 [alpine:latest]

3. add container '95bebd030e6c' to exclusion.
\# echo 95bebd030e6c > /etc/docker-gc-exclude-containers
\# DRY_RUN=1 ./docker-gc
[2017-08-31T09:59:46] [INFO] : Container not running 95bebd030e6c1016314551c7966c8a5479cfc5a3005c8c5e8d4d4f1efe9df151 /focused_panini

4. '95bebd030e6c' is still in 'EXCLUDE_CONTAINER_IDS_FILE' after cleanup 'EXCLUDE_CONTAINERS_FROM_GC' profile.
\# > /etc/docker-gc-exclude-containers
\# DRY_RUN=1 ./docker-gc
[2017-08-31T09:59:59] [INFO] : Container not running 95bebd030e6c1016314551c7966c8a5479cfc5a3005c8c5e8d4d4f1efe9df151 /focused_panini
\# cat /var/lib/docker-gc/exclude_container_ids 
95bebd030e6c