### PR TITLE
Splitted GRACE_PERIOD_SECONDS into 2 different settings: IMAGE/CONTAINER

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ FORCE_CONTAINER_REMOVAL=1 docker-gc
 
 ### Excluding Recently Exited Containers and Images From Garbage Collection
 
-By default, docker-gc will not remove a container if it exited less than 3600 seconds (1 hour) ago. In some cases you might need to change this setting (e.g. you need exited containers to stick around for debugging for several days). Set the `GRACE_PERIOD_SECONDS` variable to override this default.
+By default, docker-gc will not remove a container if it exited less than 3600 seconds (1 hour) ago. In some cases you might need to change this setting (e.g. you need exited containers to stick around for debugging for several days). Set the `CONTAINER_GRACE_PERIOD_SECONDS` variable to override this default.
 
 ```
-GRACE_PERIOD_SECONDS=86400 docker-gc
+CONTAINER_GRACE_PERIOD_SECONDS=86400 docker-gc
 ```
 
-This setting also prevents the removal of images that have been created less than `GRACE_PERIOD_SECONDS` seconds ago.
+You can also prevent the removal of images that have been created less than `IMAGE_GRACE_PERIOD_SECONDS` seconds ago.
 
 ### Dry run
 By default, docker-gc will proceed with deletion of containers and images. To test your command-line options set the `DRY_RUN` variable to override this default.

--- a/docker-gc
+++ b/docker-gc
@@ -43,6 +43,8 @@ set -o nounset
 set -o errexit
 
 GRACE_PERIOD_SECONDS=${GRACE_PERIOD_SECONDS:=3600}
+CONTAINER_GRACE_PERIOD_SECONDS=${CONTAINER_GRACE_PERIOD_SECONDS:=$GRACE_PERIOD_SECONDS}
+IMAGE_GRACE_PERIOD_SECONDS=${IMAGE_GRACE_PERIOD_SECONDS:=$GRACE_PERIOD_SECONDS}
 MINIMUM_IMAGES_TO_SAVE=${MINIMUM_IMAGES_TO_SAVE:=0}
 STATE_DIR=${STATE_DIR:=/var/lib/docker-gc}
 FORCE_CONTAINER_REMOVAL=${FORCE_CONTAINER_REMOVAL:=0}
@@ -218,13 +220,13 @@ fi
 
 container_log "Container not running" containers.exited
 
-# Find exited containers that finished at least GRACE_PERIOD_SECONDS ago
+# Find exited containers that finished at least CONTAINER_GRACE_PERIOD_SECONDS ago
 > containers.reap.tmp
 cat containers.exited | while read line
 do
     EXITED=$(${DOCKER} inspect -f "{{json .State.FinishedAt}}" ${line})
     ELAPSED=$(elapsed_time $EXITED)
-    if [[ $ELAPSED -gt $GRACE_PERIOD_SECONDS ]]; then
+    if [[ $ELAPSED -gt $CONTAINER_GRACE_PERIOD_SECONDS ]]; then
         echo $line >> containers.reap.tmp
     fi
 done
@@ -257,13 +259,13 @@ done
 # Add dangling images to list.
 $DOCKER images --no-trunc --format "{{.ID}}" --filter dangling=true >> images.all
 
-# Find images that are created at least GRACE_PERIOD_SECONDS ago
+# Find images that are created at least IMAGE_GRACE_PERIOD_SECONDS ago
 > images.reap.tmp
 cat images.all | sort | uniq | while read line
 do
     CREATED=$(${DOCKER} inspect -f "{{.Created}}" ${line})
     ELAPSED=$(elapsed_time $CREATED)
-    if [[ $ELAPSED -gt $GRACE_PERIOD_SECONDS ]]; then
+    if [[ $ELAPSED -gt $IMAGE_GRACE_PERIOD_SECONDS ]]; then
         echo $line >> images.reap.tmp
     fi
 done


### PR DESCRIPTION
For our workflow, the required grace_period for images and containers are different. So we added the CONTAINER_GRACE_PERIOD_SECONDS and IMAGE_GRACE_PERIOD_SECONDS settings, in a backward compatible way.