### PR TITLE
Dockerfile adaptation to official docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,6 @@
-FROM gliderlabs/alpine:3.2
+FROM library/docker:17.09.0-ce
 
-ENV DOCKER_VERSION 17.09.0-ce
-
-# We get curl so that we can avoid a separate ADD to fetch the Docker binary, and then we'll remove it
-RUN apk --update add bash curl \
-  && cd /tmp/ \
-  && curl -sSL -O https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
-  && tar zxf docker-${DOCKER_VERSION}.tgz \
-  && mkdir -p /usr/local/bin/ \
-  && mv $(find -name 'docker' -type f) /usr/local/bin/ \
-  && chmod +x /usr/local/bin/docker \
-  && apk del curl \
-  && rm -rf /tmp/* \
-  && rm -rf /var/cache/apk/*
+RUN apk --update add bash
 
 COPY ./docker-gc /docker-gc
 


### PR DESCRIPTION
This pull request comes from the discussion had in the [previous one](https://github.com/spotify/docker-gc/pull/182) about updating the dockerfile to take into consideration the latest docker community edition versions.

As @davidcaste commented there it'd be a good idea to use said official images in order to clean up the dockerfile and avoid maintaining it through the different docker versions and repositories, this is my approach.
