### PR TITLE
Derive version in rpm spec

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -8,3 +8,6 @@ rpm:
 		--define "_topdir `pwd`" \
 		--define "_sourcedir %{_topdir}/.." \
 	    -ba ./docker-gc.spec
+
+clean:
+	rm -rfv BUILD BUILDROOT SPECS SRPMS RPMS

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -4,6 +4,7 @@
 rpm:
 	mkdir -p BUILDROOT/
 	rpmbuild \
+		--define "version `< ../version.txt`" \
 		--define "_topdir `pwd`" \
 		--define "_sourcedir %{_topdir}/.." \
 	    -ba ./docker-gc.spec

--- a/rpm/docker-gc.spec
+++ b/rpm/docker-gc.spec
@@ -1,5 +1,5 @@
 Name: docker-gc
-Version: 0.1.0
+Version: %{version}
 Release: 1%{?dist}
 Summary: Docker garbage collection of containers and images.
 BuildArch: noarch


### PR DESCRIPTION
Uses the `version.txt` file for the version macro in the rpm spec.  Also adds `make clean` rules for removing artifacts leftover from rpmbuild